### PR TITLE
fix: real-valued high BC anisotropy on NumPy >= 2

### DIFF
--- a/superblockify/metrics/measures.py
+++ b/superblockify/metrics/measures.py
@@ -755,12 +755,14 @@ def __calculate_high_bc_anisotropy(coord_high_bc):
         )
     # Covariance matrix
     cov = np.cov(coord_high_bc.T)
-    # Eigenvalues
-    eigvals = np.linalg.eigvals(cov)
-    # Sort eigenvalues
-    eigvals = np.sort(eigvals)[::-1]
-    # Anisotropy
-    return eigvals[0] / eigvals[1]
+    # Eigenvalues - the covariance matrix is symmetric, so use eigvalsh, which
+    # always returns real eigenvalues in ascending order (eigvals returns them as
+    # complex dtype on NumPy >= 2)
+    eigvals = np.linalg.eigvalsh(cov)
+    # Anisotropy - ratio of largest to smallest eigenvalue, infinite if degenerate;
+    # clip numerical-noise negative eigenvalues to zero
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return float(eigvals[-1] / max(eigvals[0], 0.0))
 
 
 def add_ltn_means(components, edge_attr):


### PR DESCRIPTION
## Description

Scheduled CI on main failed in the Partitioning and Metrics jobs: raised `RepresenterError` on values like `(5.73+0j)`, and the anisotropy special-case tests got `inf+nanj` instead of `inf`.

There was a upstream change for NumPy >= 2, where `np.linalg.eigvals` returns `complex128` eigenvalues even for real symmetric covariance matrices. This leaked complex scalars into the metrics and key figures.

This PR switches the calculation to `np.linalg.eigvalsh` (always real for symmetric input), clips numerical-noise negative eigenvalues, and returns a plain float. As a fallback, `_make_yaml_compatible` now collapses zero-imaginary complex scalars to float, so YAML dumps can't crash on a stray complex value again.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🧹 Code refactor (no functional changes)
- [ ] ✅ Test update

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

**Test configuration:**  
- OS: MacOS, NumPy 2.5.2
- `pytest "tests/metrics/test_metric.py::TestMetric::test_saving_and_loading" -k "ResidentialPart or BetweennessPart"`
- `pytest tests/partitioning/test_base.py -k "save_key_figures and Adliswil"`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally